### PR TITLE
Fix Architecture skill for Dwarves

### DIFF
--- a/character.py
+++ b/character.py
@@ -312,7 +312,7 @@ class LotFPCharacter(AscendingAcMixin, Character):
             for s in random.choice(characterclass.LOTFP['specialist_builds']):
                 skills[s] = skills[s] + 1
         elif self.character_class == characterclass.DWARF:
-            skills['Architeure'] = 3
+            skills['Architecture'] = 3
         elif self.character_class == characterclass.ELF:
             skills['Search'] = 2
         elif self.character_class == characterclass.HALFLING:
@@ -746,5 +746,3 @@ class DelvingDeeperCharacter(LBBCharacter):
             elif val >= 18:
                 return 4
         return 0
-
-


### PR DESCRIPTION
I noticed that Dwarves had two Architecture skill listings, then realized this is because one of them is misspelled and thus line 315 in `character.py` actually creates a new dict entry rather than updating an existing one. 
